### PR TITLE
Support for different BigQuery locations

### DIFF
--- a/bigquery_to_pubsub/service/bigquery_to_file_job.py
+++ b/bigquery_to_pubsub/service/bigquery_to_file_job.py
@@ -53,7 +53,6 @@ class BigQueryToFileJob:
         ))
 
         # Query
-        # TODO: Make sure it works with different locations.
 
         random_name = random_string(10)
         destination_table = self.bigquery_client.dataset(self.temp_bigquery_dataset).table(
@@ -79,7 +78,6 @@ class BigQueryToFileJob:
         object = filename
         destination_uri = "gs://{}/{}".format(bucket, object)
         extract_job_config = bigquery.ExtractJobConfig()
-        extract_job_config.priority = bigquery.QueryPriority.INTERACTIVE
         extract_job_config.destination_format = bigquery.job.DestinationFormat.NEWLINE_DELIMITED_JSON
 
         extract_job = self.bigquery_client.extract_table(

--- a/bigquery_to_pubsub/service/bigquery_to_file_job.py
+++ b/bigquery_to_pubsub/service/bigquery_to_file_job.py
@@ -35,11 +35,13 @@ class BigQueryToFileJob:
             self,
             sql,
             output_filename,
+            location,
             temp_bigquery_dataset,
             temp_bucket):
         self.sql = sql
         self.output_filename = output_filename
 
+        self.location = location
         self.temp_bigquery_dataset = temp_bigquery_dataset
         self.temp_bucket = temp_bucket
 
@@ -62,6 +64,7 @@ class BigQueryToFileJob:
 
         query_job = self.bigquery_client.query(
             self.sql,
+            location=self.location,
             job_config=query_job_config
         )
 

--- a/bigquery_to_pubsub/service/replay_job.py
+++ b/bigquery_to_pubsub/service/replay_job.py
@@ -54,7 +54,7 @@ class ReplayJob:
         for batch_start_timestamp, batch_end_timestamp in batches:
             file = self.time_series_bigquery_to_file_service.download_time_series(batch_start_timestamp, batch_end_timestamp)
 
-            with open(file) as file_handle:
+            with open(file, encoding='utf-8') as file_handle:
                 for line in file_handle:
                     item = json.loads(line, parse_float=decimal.Decimal)
                     self.replayer.replay(item)

--- a/setup.py
+++ b/setup.py
@@ -31,16 +31,16 @@ setup(
     keywords=['bigquery', 'pubsub', 'gcp'],
     python_requires='>=3.5.3,<3.8.0',
     install_requires=[
-        'click==7.0',
-        'google-cloud-pubsub==1.0.2',
-        'google-cloud-storage==1.20.0',
-        'google-cloud-bigquery==1.21.0',
-        'timeout-decorator==0.4.1',
-        'python-dateutil==2.7.0',
+        'click==8.0.0',
+        'google-cloud-pubsub==2.4.2',
+        'google-cloud-storage==1.38.0',
+        'google-cloud-bigquery==2.16.1',
+        'timeout-decorator==0.5.0',
+        'python-dateutil==2.8.1',
     ],
     extras_require={
         'dev': [
-            'pytest~=4.3.0'
+            'pytest~=6.2.4'
         ]
     },
     entry_points={


### PR DESCRIPTION
- [x] Added a location flag to support different locations. Note that the temp_dataset and the temp_bucket have to be in the same region
- [x] Update pip dependencies
- [x] Fix serialization issues : UTF_8,

## Limitations
- BQ only exports strings in JSON files, AVRO could be better or use the `TO_JSON_STRING` Standard SQL function instead : https://cloud.google.com/bigquery/docs/exporting-data#export_limitations